### PR TITLE
[docs] add a sample role using rst for readme file

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -14,8 +14,14 @@ demo/
 │   └── modules
 │       └── real_facts.py
 └── roles
-    └── factoid
-        ├── README.md
+    ├── factoid
+    |   ├── README.md
+    |   ├── meta
+    |   │   └── main.yaml
+    |   └── tasks
+    |       └── main.yml
+    └── deltoid
+        ├── README.rst
         ├── meta
         │   └── main.yaml
         └── tasks

--- a/demo/roles/deltoid/README.rst
+++ b/demo/roles/deltoid/README.rst
@@ -1,0 +1,38 @@
+Deltoid Role
+============
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/demo/roles/deltoid/meta/main.yaml
+++ b/demo/roles/deltoid/meta/main.yaml
@@ -1,0 +1,15 @@
+galaxy_info:
+  author: Sandra McCann
+  description: A dummy role for demoing RST readme in collections.
+  company: Red Hat
+  license: MIT
+
+  min_ansible_version: 2.8
+  platforms:
+    - name: Fedora
+      versions:
+        - 29
+
+  galaxy_tags: ["demo", "muscles"]
+
+dependencies: []

--- a/demo/roles/deltoid/tasks/main.yml
+++ b/demo/roles/deltoid/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: Gather some real facts FROM A DELTOID ROLE!
+  newswangerd.demo.real_facts:
+    name: RMS
+  register: testout
+- debug:
+    msg: "{{ testout }}"


### PR DESCRIPTION
Copied the existing factoid role folder into a deltoid role folder (cuz I think I'm funny) - and modified the role/README.md to be a README.rst file.  Haven't added any special rst-lik formatting as the first test should be does .rst work at all.